### PR TITLE
Update MakeEnumCommand to use Enums subfolder

### DIFF
--- a/src/Commands/MakeEnumCommand.php
+++ b/src/Commands/MakeEnumCommand.php
@@ -8,4 +8,14 @@ use Joerucci\DomainTools\Concerns\InteractsWithDomains;
 class MakeEnumCommand extends EnumMakeCommand
 {
     use InteractsWithDomains;
+
+    protected function rootNamespace(): string
+    {
+        return 'App\\'.$this->getStudlyDomain().'\\Enums\\';
+    }
+
+    protected function getPath($name)
+    {
+        return parent::getPath($this->getStudlyDomain().'\\Enums\\'.$name);
+    }
 }

--- a/tests/MakeEnumCommandTest.php
+++ b/tests/MakeEnumCommandTest.php
@@ -10,7 +10,7 @@ class MakeEnumCommandTest extends TestCase
             command: 'make:enum',
             name: 'StatusEnum',
             domain: 'Auth',
-            expectedRelativePath: 'StatusEnum.php'
+            expectedRelativePath: 'Enums/StatusEnum.php'
         );
     }
 }


### PR DESCRIPTION
## Summary
- ensure enums are generated inside an `Enums` folder within the chosen domain
- update MakeEnumCommand test accordingly